### PR TITLE
Smart Quotes used instead of Single Quotes, fixed

### DIFF
--- a/Public/Add-DefaultDisplaySet.ps1
+++ b/Public/Add-DefaultDisplaySet.ps1
@@ -15,7 +15,7 @@ function Add-DefaultDisplaySet {
 	}
 	# Create the default property display set
 	$DefaultDisplayPropertySet = New-Object System.Management.Automation.PSPropertySet(
-	    ‘DefaultDisplayPropertySet’,[string[]]$DefaultDisplaySet
+	    'DefaultDisplayPropertySet',[string[]]$DefaultDisplaySet
 	)
 	$PSStandardMembers = [System.Management.Automation.PSMemberInfo[]]@($DefaultDisplayPropertySet)
 	$Object | Add-Member MemberSet PSStandardMembers $PSStandardMembers


### PR DESCRIPTION
This was causing the module to error out on line 18. Smart Quotes presumed a consequence of a non-supported editor autocorrect.