### PR TITLE
Nt branch

### DIFF
--- a/Public/New-ModuleTemplate.ps1
+++ b/Public/New-ModuleTemplate.ps1
@@ -62,7 +62,7 @@ function New-ModuleTemplate {
     Param (
 	[Parameter(Mandatory,ValueFromPipeline)]
 	[string[]]$Names,
-	[System.IO.FileInfo]$Path=($env:PSModulePath -split ':|;' | Select-Object -last 1),
+	[System.IO.FileInfo]$Path=$(Get-Item -Path .\).FullName,
 	[string]$Author=$env:USER,
 	[string]$CompanyName="",
 	[string]$Description="Module Description",

--- a/Public/New-ModuleTemplate.ps1
+++ b/Public/New-ModuleTemplate.ps1
@@ -62,7 +62,7 @@ function New-ModuleTemplate {
     Param (
 	[Parameter(Mandatory,ValueFromPipeline)]
 	[string[]]$Names,
-	[System.IO.FileInfo]$Path=$(Get-Item -Path .\).FullName,
+	[System.IO.DirectoryInfo]$Path=$(Get-Item -Path .\).FullName,
 	[string]$Author=$env:USER,
 	[string]$CompanyName="",
 	[string]$Description="Module Description",


### PR DESCRIPTION
As per my last commit, changed the default value and type of the 'Path' parameter, this is because the module can be run from path and the module could be installed in to the user modules path and not being run from the local directory. 